### PR TITLE
Setup phantomjs from binary download

### DIFF
--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -21,6 +21,7 @@ RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main' > /e
     mkdir /opt/phantomjs && \
     tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /opt/phantomjs/ && \
     sudo ln -s /opt/phantomjs/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/bin/phantomjs && \
+    rm phantomjs-2.1.1-linux-x86_64.tar.bz2 phantomjs-2.1.1-linux-x86_64.tar.bz2.sha256 && \
     apt-add-repository -y ppa:git-core/ppa && \
     apt-get update && \
     echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -14,7 +14,13 @@ RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main' > /e
     apt-get update && \
     apt-get install -y --force-yes --no-install-recommends software-properties-common sudo openssh-client \
      gnupg2 gnupg-curl hopenpgp-tools file bash-completion iputils-ping bind9-host traceroute netcat tcpdump \
-      strace psmisc wget curl ca-certificates lsof vim nodejs phantomjs bc emacs ruby2.3 ruby-bundler firefox=45.0.2+build1-0ubuntu1 && \
+      strace psmisc wget curl bzip2 ca-certificates lsof vim nodejs bc emacs ruby2.3 ruby-bundler firefox=45.0.2+build1-0ubuntu1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    echo 86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f  phantomjs-2.1.1-linux-x86_64.tar.bz2 > phantomjs-2.1.1-linux-x86_64.tar.bz2.sha256 && \
+    sha256sum --check phantomjs-2.1.1-linux-x86_64.tar.bz2.sha256 && \
+    mkdir /opt/phantomjs && \
+    tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /opt/phantomjs/ && \
+    sudo ln -s /opt/phantomjs/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/bin/phantomjs && \
     apt-add-repository -y ppa:git-core/ppa && \
     apt-get update && \
     echo oracle-java${JAVA_VER}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \


### PR DESCRIPTION
Added phantomjs binary download to opt with a symlink to /usr/bin. Removed faulty apt-get install of phantomjs.