### PR TITLE
Installed dirmngr in the container

### DIFF
--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -13,7 +13,7 @@ RUN echo 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main' > /e
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 99E82A75642AC823 && \
     apt-get update && \
     apt-get install -y --allow-change-held-packages --no-install-recommends software-properties-common sudo openssh-client apt-transport-https \
-     gnupg2 gnupg-curl hopenpgp-tools file bash-completion iputils-ping bind9-host traceroute netcat tcpdump \
+     gnupg2 gnupg-curl hopenpgp-tools dirmngr file bash-completion iputils-ping bind9-host traceroute netcat tcpdump \
       strace psmisc wget curl bzip2 ca-certificates lsof vim bc emacs ruby2.3 ruby-bundler \
       dbus dbus-x11 ruby-dev build-essential && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - && \


### PR DESCRIPTION
This is an optional dependency for GPG, necessary for communicating
with the keyserver.